### PR TITLE
Update event generation for physical samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+condor_*.sub
+fmokhtar.cc
+std/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ In order to use the repo:
 `git clone https://github.com/key4hep/CLDConfig/tree/main/CLDConfig`
 update the path in `scripts/run_sequence_CLD_train.sh`. 
 
-The script `script_create_dataset_train.sh` can be used to create condor jobs, by default for the gun there are 100 events, configure in the config. 
+The script `script_create_dataset_train_gun.sh` can be used to create condor jobs, by default for the gun there are 100 events, configure in the config. 
 The gun config in `gun/config_files/*.gun` includes:
 `npart_range 10,15 %range of number of particles`
 `eta_range -0.5,0.5   %eta range`
@@ -10,3 +10,5 @@ The gun config in `gun/config_files/*.gun` includes:
 `drmax 0.5  %if dr max is larger than 0 it generates particles with sqrt((eta)**2+(phi)**2)<drmax, if it's 0 then it create random angles `
 `pid_list 211,-211,130,130,2112,2112,-2112,-2112,22,22,22,22,22,22,11,-11,11,-11,11,-11,13,-13,13,-13,13,-13,-321,321,2212,-2212 %pdg of particles (they need to be available in the gun definition otherwise the mass is 0)`
 `nevents 100`
+
+The script `script_create_dataset_train_ttbar.sh` can be used to create condor jobs for `p8_ee_tt_ecm365` events, by default there are 100 events, configure in the config. 

--- a/pythia/p8_ee_tt_ecm365.cmd
+++ b/pythia/p8_ee_tt_ecm365.cmd
@@ -1,0 +1,33 @@
+Random:setSeed = on
+Main:numberOfEvents = 1000         ! number of events to generate
+Main:timesAllowErrors = 5          ! how many aborts before run stops
+
+! 2) Settings related to output in init(), next() and stat().
+Init:showChangedSettings = on      ! list changed settings
+Init:showChangedParticleData = off ! list changed particle data
+Next:numberCount = 100             ! print message every n events
+Next:numberShowInfo = 1            ! print event information n times
+Next:numberShowProcess = 1         ! print process record n times
+Next:numberShowEvent = 0           ! print event record n times
+
+Beams:idA = 11                   ! first beam, e+ = 11
+Beams:idB = -11                   ! second beam, e- = -11
+
+Beams:allowMomentumSpread  = off
+
+! Vertex smearing :
+Beams:allowVertexSpread = on
+Beams:sigmaVertexX = 27.3e-3   
+Beams:sigmaVertexY = 48.8E-6    
+Beams:sigmaVertexZ = 1.33       
+Beams:sigmaTime = 1.94    !  6.46 ps
+
+
+! 3) Hard process : tt at 365 GeV
+Beams:eCM = 365  ! CM energy of collision
+Top:ffbar2ttbar(s:gmZ) = on
+
+! 4) Settings for the event generation process in the Pythia8 library.
+PartonLevel:ISR = on               ! no initial-state radiation
+PartonLevel:FSR = on               ! no final-state radiation
+

--- a/scripts/run_sequence_CLD_train.sh
+++ b/scripts/run_sequence_CLD_train.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
-HOMEDIR=${1} # path to where it's ran from
+HOMEDIR=${1} # path to where it's ran from e.g. /afs/cern.ch/user/f/fmokhtar/MLPF_datageneration
 GUNCARD=${2}  
 NEV=${3}
 SEED=${4}
 OUTPUTDIR=${5}
 DIR=${6}
+SAMPLE=${7} # can be "gun" or "p8_ee_tt_ecm365"
 
-mkdir ${DIR}
-mkdir ${DIR}/${SEED}
+mkdir -p ${DIR}/${SEED}
 cd ${DIR}/${SEED}
 
-SAMPLE="gun"
 
-PATH_CLDCONFIG=/afs/cern.ch/work/m/mgarciam/private/CLD_Config_versions/CLDConfig_030225/CLDConfig/ 
+# PATH_CLDCONFIG=/afs/cern.ch/work/m/mgarciam/private/CLD_Config_versions/CLDConfig_030225/CLDConfig/ 
+PATH_CLDCONFIG=/afs/cern.ch/user/f/fmokhtar/MLPF_datageneration/CLDConfig/CLDConfig
 
 
 wrapperfunction() {
@@ -37,22 +37,23 @@ then
     ./build/gun ${PATH_GUN_CONFIG} 
 fi
 
-if [[ "${SAMPLE}" == "Zcard" ]]
+if [[ "${SAMPLE}" == "p8_ee_tt_ecm365" ]]
 then
-    cp ${HOMEDIR}/Pythia_generation/${SAMPLE}.cmd card.cmd
+    xrdcp ${HOMEDIR}/pythia/${SAMPLE}.cmd card.cmd
     echo "Random:seed=${SEED}" >> card.cmd
     cat card.cmd
-    k4run pythia.py -n $NEV --Dumper.Filename out.hepmc --Pythia8.PythiaInterface.pythiacard card.cmd
+    k4run ${HOMEDIR}/pythia/pythia.py -n $NEV --Dumper.Filename out.hepmc --Pythia8.PythiaInterface.pythiacard card.cmd
     cp out.hepmc events.hepmc
 fi
 
 
 ddsim --compactFile $K4GEO/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml --outputFile out_sim_edm4hep.root --steeringFile ${PATH_CLDCONFIG}/cld_steer.py --inputFiles events.hepmc --numberOfEvents ${NEV} --random.seed ${SEED}
 
-cp -r /afs/cern.ch/work/m/mgarciam/private/CLD_Config_versions/CLDConfig_030225/CLDConfig/* .
-k4run CLDReconstruction.py -n ${NEV}  --inputFiles out_sim_edm4hep.root --outputBasename out_reco_edm4hep
+# copy large input files via xrootd (recommended)
+xrdcp -r ${PATH_CLDCONFIG}/* .
+k4run CLDReconstruction.py -n ${NEV}  --inputFiles out_sim_edm4hep.root --outputBasename out_reco
 
 
 
 mkdir -p ${OUTPUTDIR}
-python /afs/cern.ch/work/f/fccsw/public/FCCutils/eoscopy.py out_sim_edm4hep.root ${OUTPUTDIR}/out_sim_edm4hep_${SEED}.root
+xrdcp ${DIR}/${SEED}/out_reco_REC.edm4hep.root ${OUTPUTDIR}/reco_${SAMPLE}_${SEED}.root

--- a/scripts/run_sequence_CLD_train.sh
+++ b/scripts/run_sequence_CLD_train.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+####################################################################################################
 HOMEDIR=${1} # path to where it's ran from e.g. /afs/cern.ch/user/f/fmokhtar/MLPF_datageneration
 GUNCARD=${2}  
 NEV=${3}
@@ -7,13 +8,21 @@ SEED=${4}
 OUTPUTDIR=${5}
 DIR=${6}
 SAMPLE=${7} # can be "gun" or "p8_ee_tt_ecm365"
+CLDGEO=${8} # default is CLD_o2_v06 (CLD+ARC is CLD_o3_v01 https://github.com/key4hep/k4geo/blob/main/FCCee/CLD/compact/CLD_o3_v01/CLD_o3_v01.xml)
+
+if [ -z "$CLDGEO" ]; then
+    echo "Will use default CLD geometry version CLD_o2_v06"
+    CLDGEO=CLD_o2_v06
+else
+    echo "Will use CLD geometry version $CLDGEO"
+fi
+
+PATH_CLDCONFIG=/afs/cern.ch/user/f/fmokhtar/MLPF_datageneration/CLDConfig/CLDConfig
+
+####################################################################################################
 
 mkdir -p ${DIR}/${SEED}
 cd ${DIR}/${SEED}
-
-
-# PATH_CLDCONFIG=/afs/cern.ch/work/m/mgarciam/private/CLD_Config_versions/CLDConfig_030225/CLDConfig/ 
-PATH_CLDCONFIG=/afs/cern.ch/user/f/fmokhtar/MLPF_datageneration/CLDConfig/CLDConfig
 
 
 wrapperfunction() {
@@ -47,7 +56,8 @@ then
 fi
 
 
-ddsim --compactFile $K4GEO/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml --outputFile out_sim_edm4hep.root --steeringFile ${PATH_CLDCONFIG}/cld_steer.py --inputFiles events.hepmc --numberOfEvents ${NEV} --random.seed ${SEED}
+
+ddsim --compactFile $K4GEO/FCCee/CLD/compact/$CLDGEO/$CLDGEO.xml --outputFile out_sim_edm4hep.root --steeringFile ${PATH_CLDCONFIG}/cld_steer.py --inputFiles events.hepmc --numberOfEvents ${NEV} --random.seed ${SEED}
 
 # copy large input files via xrootd (recommended)
 xrdcp -r ${PATH_CLDCONFIG}/* .

--- a/scripts/script_create_dataset_train.sh
+++ b/scripts/script_create_dataset_train.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-python submit_jobs_train.py --config config_spread_031224_fair.gun --outdir /eos/experiment/fcc/users/m/mgarciam/mlpf/CLD/train/gun_dr_log_logE_v0_290125/  --condordir /eos/experiment/fcc/users/m/mgarciam/mlpf/condor/gun_dr_log_logE_v0_290125/  --njobs 8000 --nev 100 --queue workday
-

--- a/scripts/script_create_dataset_train_gun.sh
+++ b/scripts/script_create_dataset_train_gun.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python3 submit_jobs_train.py --sample gun --config config_spread_031224_fair.gun --outdir /eos/user/f/fmokhtar/mlpf/CLD/Feb21/  --condordir /eos/user/f/fmokhtar/mlpf/condor/Feb21/gun/ --njobs 4 --nev 2 --queue workday
+

--- a/scripts/script_create_dataset_train_ttbar.sh
+++ b/scripts/script_create_dataset_train_ttbar.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python3 submit_jobs_train.py --sample p8_ee_tt_ecm365 --outdir /eos/user/f/fmokhtar/mlpf/CLD/Feb21/ --condordir /eos/user/f/fmokhtar/mlpf/condor/Feb21/p8_ee_tt_ecm365/ --njobs 4 --nev 2 --queue workday
+

--- a/scripts/script_create_dataset_train_ttbar_cldplusarc.sh
+++ b/scripts/script_create_dataset_train_ttbar_cldplusarc.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python3 submit_jobs_train.py --sample p8_ee_tt_ecm365 --cldgeo CLD_o3_v01 --outdir /eos/user/f/fmokhtar/mlpf/CLD/Feb21/ --condordir /eos/user/f/fmokhtar/mlpf/condor/Feb21/p8_ee_tt_ecm365/ --njobs 10 --nev 100 --queue workday
+

--- a/scripts/script_create_dataset_train_ttbar_cldplusarc.sh
+++ b/scripts/script_create_dataset_train_ttbar_cldplusarc.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-python3 submit_jobs_train.py --sample p8_ee_tt_ecm365 --cldgeo CLD_o3_v01 --outdir /eos/user/f/fmokhtar/mlpf/CLD/Feb21/ --condordir /eos/user/f/fmokhtar/mlpf/condor/Feb21/p8_ee_tt_ecm365/ --njobs 10 --nev 100 --queue workday
-

--- a/scripts/submit_jobs_train.py
+++ b/scripts/submit_jobs_train.py
@@ -30,7 +30,7 @@ def main():
 
     parser.add_argument(
         "--config",
-        help="gun config file (has to be in gun/ directory) ",
+        help="gun config file (has to be in gun/ directory)",
         default="config.gun",
     )
     
@@ -38,6 +38,11 @@ def main():
         "--sample",
         help="gun / p8_ee_tt_ecm365",
         default="gun",
+    )
+    parser.add_argument(
+        "--cldgeo",
+        help="which cld geometry version to use",
+        default="CLD_o2_v06",
     )
 
     parser.add_argument(
@@ -73,6 +78,7 @@ def main():
     condor_dir = os.path.abspath(args.condordir)
     config = args.config
     sample = args.sample
+    cldgeo = args.cldgeo
     njobs = int(args.njobs)
     nev = args.nev
     queue = args.queue
@@ -115,7 +121,7 @@ log                   = std/condor.$(ClusterId).log
             jobCount += 1
 
             argts = "{} {} {} {} {} {} {}".format(
-                homedir, config, nev, seed, outdir, condor_dir, sample
+                homedir, config, nev, seed, outdir, condor_dir, sample, cldgeo
             )
 
             cmdfile += 'arguments="{}"\n'.format(argts)

--- a/scripts/submit_jobs_train.py
+++ b/scripts/submit_jobs_train.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
-import os, sys, subprocess
-import glob
 import argparse
+import glob
+import os
+import subprocess
+import sys
 import time
 
 # ____________________________________________________________________________________________________________
@@ -30,6 +32,12 @@ def main():
         "--config",
         help="gun config file (has to be in gun/ directory) ",
         default="config.gun",
+    )
+    
+    parser.add_argument(
+        "--sample",
+        help="gun / p8_ee_tt_ecm365",
+        default="gun",
     )
 
     parser.add_argument(
@@ -64,6 +72,7 @@ def main():
     outdir = os.path.abspath(args.outdir)
     condor_dir = os.path.abspath(args.condordir)
     config = args.config
+    sample = args.sample
     njobs = int(args.njobs)
     nev = args.nev
     queue = args.queue
@@ -105,8 +114,8 @@ log                   = std/condor.$(ClusterId).log
             print("{} : missing output file ".format(outputFile))
             jobCount += 1
 
-            argts = "{} {} {} {} {} {}".format(
-                homedir, config, nev, seed, outdir, condor_dir
+            argts = "{} {} {} {} {} {} {}".format(
+                homedir, config, nev, seed, outdir, condor_dir, sample
             )
 
             cmdfile += 'arguments="{}"\n'.format(argts)
@@ -117,14 +126,14 @@ log                   = std/condor.$(ClusterId).log
                 print("")
                 print(cmd)
 
-    with open("condor_gun.sub", "w") as f:
+    with open("condor_{}.sub".format(sample), "w") as f:
         f.write(cmdfile)
 
     ### submitting jobs
     if jobCount > 0:
         print("")
         print("[Submitting {} jobs] ... ".format(jobCount))
-        os.system("condor_submit condor_gun.sub")
+        os.system("condor_submit condor_{}.sub".format(sample))
 
 
 # _______________________________________________________________________________________


### PR DESCRIPTION
- add pythia ttbar 365GeV card
- rename the condor submission script: `script_create_dataset_train.sh` -> `script_create_dataset_train_gun.sh`
- add condor submission script for ttbar: `script_create_dataset_train_ttbar.sh`
- include additional argument `sample` that takes values [`gun`, `p8_ee_tt_ecm365`]
- make CLD geometry configurable default is `CLD_o2_v06` (can pass `CLD_o3_v01`, or `CLD_o2_v05`)

**Tested local commands**
For gun
`./run_sequence_CLD_train.sh /afs/cern.ch/user/f/fmokhtar/MLPF_datageneration config_spread_031224_fair.gun 4 2 /afs/cern.ch/user/f/fmokhtar/MLPF_datageneration/scripts/Feb21outdir /afs/cern.ch/user/f/fmokhtar/MLPF_datageneration/scripts/Feb21indir gun`

For ttbar
`./run_sequence_CLD_train.sh /afs/cern.ch/user/f/fmokhtar/MLPF_datageneration none 4 2 /afs/cern.ch/user/f/fmokhtar/MLPF_datageneration/scripts/Feb21outdir /afs/cern.ch/user/f/fmokhtar/MLPF_datageneration/scripts/Feb21indir p8_ee_tt_ecm365 CLD_o3_v01`

**Tested condor submission** 
For gun: 
`./script_create_dataset_train_gun.sh`

For ttbar:
`./script_create_dataset_train_ttbar.sh`